### PR TITLE
Make lexer iterable

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint:fix": "prettier --write 'src/**/*.ts'",
     "precommit": "npm run lint && npm run test",
     "prepack": "tsc && npm test",
+    "build": "tsc",
     "test": "tape -r 'ts-node/register' test/index.ts"
   },
   "keywords": [],
@@ -24,7 +25,7 @@
     "tape": "^4.7.0",
     "ts-node": "^3.2.1",
     "tslint": "^4.5.1",
-    "typescript": "^2.2.1"
+    "typescript": "^3.7.2"
   },
   "repository": "https://github.com/jrop/perplex",
   "publishConfig": {

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -24,8 +24,10 @@ import TokenTypes from './token-types'
  * }
  * // alternatively:
  * console.log(lex.toArray())
+ * // or:
+ * console.log(...lex)
  */
-class Lexer<T> {
+class Lexer<T> implements Iterable<Token<T>> {
 	/* tslint:disable:variable-name */
 	private _state: LexerState<T>
 	private _tokenTypes: TokenTypes<T>
@@ -178,7 +180,7 @@ class Lexer<T> {
 							i,
 							i + n.result[0].length,
 							this
-						)
+					  )
 				: null
 		}
 		const t = read()
@@ -224,18 +226,25 @@ class Lexer<T> {
 	 * @return {Token<T>[]} The array of tokens (not including (EOF))
 	 */
 	toArray(): Token<T>[] {
+		return [...this]
+	}
+
+	/**
+	 * Implements the Iterable protocol
+	 * Iterates lazily over the entire token stream (not including (EOF))
+	 * @return {Iterator<Token<T>>} Returns an iterator over all remaining tokens
+	 */
+	*[Symbol.iterator]() {
 		const oldState = this._state.copy()
 		this._state.position = 0
 
-		const tkns: Token<T>[] = []
 		let t
 		while (
 			!(t = this.next()).isEof() // tslint:disable-line no-conditional-assignment
 		)
-			tkns.push(t)
+			yield t
 
 		this._state = oldState
-		return tkns
 	}
 
 	/**

--- a/src/token-types.ts
+++ b/src/token-types.ts
@@ -56,10 +56,13 @@ export default class TokenTypes<T> {
 
 	peek(source: string, position: number) {
 		const s = source.substr(position)
-		return first(this.tokenTypes.filter(tt => tt.enabled), tt => {
-			tt.regex.lastIndex = 0
-			return tt.regex.exec(s)
-		})
+		return first(
+			this.tokenTypes.filter(tt => tt.enabled),
+			tt => {
+				tt.regex.lastIndex = 0
+				return tt.regex.exec(s)
+			}
+		)
 	}
 
 	token(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2017"],
+    "downlevelIteration": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es5",


### PR DESCRIPTION
This permits using modern spread syntax and `for...of` loops over token streams with lazy production of tokens, so you don't have to load the entire token stream into memory with `.toArray()` first.